### PR TITLE
fix(quicklink-strategy): check for navigator existence

### DIFF
--- a/src/quicklink-strategy.service.ts
+++ b/src/quicklink-strategy.service.ts
@@ -14,7 +14,7 @@ export class QuicklinkStrategy implements PreloadingStrategy {
       // Don't preload the same route twice
       return EMPTY;
     }
-    const conn = typeof window !== 'undefined' ? (navigator as any).connection : undefined;
+    const conn = typeof navigator !== 'undefined' ? (navigator as any).connection : undefined;
     if (conn) {
       // Don't preload if the user is on 2G. or if Save-Data is enabled..
       if ((conn.effectiveType || '').includes('2g') || conn.saveData) return EMPTY;


### PR DESCRIPTION
Summary
--
We use [angular-prerender](https://github.com/chrisguttandin/angular-prerender) to prerender our app, and ran into an issue where `window` is defined in that prerender process, but `navigator` is not. This updates `QuicklinkStrategy` to check for the existing of `navigator` before trying to access the `connection` property on it.