### PR TITLE
fix(quicklink-strategy): add force preload route option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ export const routes: Routes = [
 
 ```
 
+If you want to force preload a route immediately, use the `data` property:
+
+```ts
+export const routes: Routes = [
+  {
+    path: 'contact',
+    loadChildren: import(() => './contact/contact.module').then(m => m.ContactModule),
+    data: {
+      preload: true
+    }
+  }
+];
+
+```
+
 **Note that to make the module available in lazy-loaded modules as well you need to import it in a shared module and export it.** Look at [this commit](https://github.com/mgechev/angular-realworld-example-app-qucklink/commit/33ea101c7d84bb5ca086f107148bbc958659f83f) to see how `ngx-quicklink` is integrated in the [angular-realworld-example-app](https://github.com/gothinkster/angular-realworld-example-app).
 
 For a demo, look at the `example` directory. To run the project use:

--- a/src/quicklink-strategy.service.ts
+++ b/src/quicklink-strategy.service.ts
@@ -17,6 +17,10 @@ export class QuicklinkStrategy implements PreloadingStrategy {
       // Don't preload the same route twice
       return EMPTY;
     }
+    if (route.data && route.data.preload === true) {
+      this.loading.add(route);
+      return load();
+    }
     const conn = typeof navigator !== 'undefined' ? (navigator as any).connection : undefined;
     if (conn) {
       // Don't preload if the user is on 2G. or if Save-Data is enabled..


### PR DESCRIPTION
HI,
This PR allows the developer to force reload a route without waiting for `ngx-quicklink` to discover it.

Fixes #81 

Let me know If I missed something and need to be updated. Thank you