### PR TITLE
Export quicklinkProviders

### DIFF
--- a/projects/ngx-quicklink/src/public-api.ts
+++ b/projects/ngx-quicklink/src/public-api.ts
@@ -2,6 +2,7 @@
  * Public API Surface of ngx-quicklink
  */
 
+export { quicklinkProviders } from './lib/quicklink.module';
 export { QuicklinkModule } from './lib/quicklink.module';
 export { LinkDirective as QuicklinkDirective } from './lib/link.directive';
 export { QuicklinkStrategy } from './lib/quicklink-strategy.service';


### PR DESCRIPTION
`quicklinkProviders` export was missing. It is required in standalone applications.